### PR TITLE
Wrap enabling webkit features in try/except blocks to gracefully handle missing features in older versions

### DIFF
--- a/upstream/Lens/LensApp.py
+++ b/upstream/Lens/LensApp.py
@@ -154,6 +154,12 @@ class LensApp():
   def on(self, name, callback):
     self._lv.on(name, callback)
 
+  def set_title(self, title):
+    self._lv._window.set_title(title)
+
+  def set_size(self, width, height):
+    self._lv._window.set_size_request(1024, 768)
+
   def run(self):
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     Gtk.main()

--- a/upstream/Lens/LensViewGTK.py
+++ b/upstream/Lens/LensViewGTK.py
@@ -40,10 +40,29 @@ class LensViewWebKitGTK(WebKit2.WebView):
     self.l_uri = None
 
     # disable right-click context menu
-    self.get_settings().set_property('enable-accelerated-2d-canvas', True)
-    self.get_settings().set_property('enable-smooth-scrolling', True)
-    self.get_settings().set_property('enable_write_console_messages_to_stdout', True)
-    self.get_settings().set_property('javascript-can-access-clipboard', True)
+    try:
+        self.get_settings().set_property('enable-accelerated-2d-canvas', True)
+    except:
+        pass
+        # TODO: log failure to set
+
+    try:
+        self.get_settings().set_property('enable-smooth-scrolling', True)
+    except:
+        pass
+        # TODO: log failure to set
+
+    try:
+        self.get_settings().set_property('enable_write_console_messages_to_stdout', True)
+    except:
+        pass
+        # TODO: log failure to set
+
+    try:
+        self.get_settings().set_property('javascript-can-access-clipboard', True)
+    except:
+        pass
+        # TODO: log failure to set
 
   def _context_menu_cb(self, view, context_menu, event, hit_test_result):
     return True


### PR DESCRIPTION
added try/except blocks to the the enable webkit features in
LensViewGTK.py

added a set_title() and set_size() function to the LensApp class
