### PR TITLE
PyGIWarning Webkit[2] imported without specifying version

### DIFF
--- a/upstream/lens/appgtk.py
+++ b/upstream/lens/appgtk.py
@@ -25,6 +25,8 @@ from lens.thread import Thread, ThreadManager
 
 # GTK
 from dbus.mainloop.glib import DBusGMainLoop
+import gi
+gi.require_version('WebKit2', '4.0')
 from gi.repository import WebKit2, Gio, Gtk, GObject, Gdk
 
 logger = logging.getLogger('Lens.Backend.Gtk3')

--- a/upstream/lens/appgtk2.py
+++ b/upstream/lens/appgtk2.py
@@ -25,6 +25,8 @@ from lens.thread import Thread, ThreadManager
 
 # GTK
 from dbus.mainloop.glib import DBusGMainLoop
+import gi
+gi.require_version('WebKit', '3.0')
 from gi.repository import WebKit, Gtk, GObject
 
 


### PR DESCRIPTION
On K23 use of the GTK backends produces the following warnings:  
* appgtk2: PyGIWarning: WebKit was imported without specifying a version first. Use gi.require_version('WebKit', '3.0') before import to ensure that the right version gets loaded.
* appgtk: PyGIWarning: WebKit2 was imported without specifying a version first. Use gi.require_version('WebKit2', '4.0') before import to ensure that the right version gets loaded.

This PR adds the recommended command before importing GTK modules.